### PR TITLE
Fee service implementation

### DIFF
--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -7,6 +7,8 @@ use {
     std::path::Path,
 };
 
+use crate::fee_service::FeeServiceConfig;
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum IngesterConfig {
     RpcBlockSubscription {
@@ -72,6 +74,8 @@ pub struct ProverNodeConfig {
     pub metrics_config: MetricsConfig,
     #[serde(default)]
     pub missing_image_strategy: MissingImageStrategy,
+    #[serde(default = "default_fee_service_config")]
+    pub fee_service_config: FeeServiceConfig,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -84,6 +88,10 @@ pub enum MetricsConfig {
 
 const fn default_metrics_config() -> MetricsConfig {
     MetricsConfig::None
+}
+
+fn default_fee_service_config() -> FeeServiceConfig {
+    FeeServiceConfig::default()
 }
 
 fn default_stark_compression_tools_path() -> String {
@@ -162,6 +170,7 @@ impl Default for ProverNodeConfig {
             stark_compression_tools_path: default_stark_compression_tools_path(),
             metrics_config: default_metrics_config(),
             missing_image_strategy: MissingImageStrategy::default(),
+            fee_service_config: default_fee_service_config(),
         }
     }
 }

--- a/node/src/fee_service.rs
+++ b/node/src/fee_service.rs
@@ -1,0 +1,349 @@
+use {
+    anyhow::Result,
+    serde::{Deserialize, Serialize},
+    solana_rpc_client::nonblocking::rpc_client::RpcClient,
+    solana_sdk::pubkey::Pubkey,
+    std::{sync::Arc, time::Duration},
+    tracing::{error, info, warn},
+};
+
+#[derive(Debug, Clone)]
+pub struct FeeEstimate {
+    pub micro_lamports_per_cu: u64,
+}
+
+/// Configuration for fee estimation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeServiceConfig {
+    pub cache_duration_secs: u64,
+    pub default_micro_lamports_per_cu: u64,
+    pub fallback_micro_lamports_per_cu: u64,
+    pub percentile: u8,
+}
+
+impl Default for FeeServiceConfig {
+    fn default() -> Self {
+        Self {
+            cache_duration_secs: 5,                // Cache for 5 seconds
+            default_micro_lamports_per_cu: 1_000,  // 1 micro-lamport per CU
+            fallback_micro_lamports_per_cu: 5_000, // 5 micro-lamports per CU fallback
+            percentile: 75,                        // Use 75th percentile by default
+        }
+    }
+}
+
+pub struct FeeService {
+    rpc_client: Arc<RpcClient>,
+    config: FeeServiceConfig,
+    last_general_fee_update: Mutex<std::time::Instant>,
+    cached_general_fee: Mutex<Option<FeeEstimate>>,
+}
+
+impl FeeService {
+    pub fn new(rpc_client: Arc<RpcClient>, config: FeeServiceConfig) -> Self {
+        Self {
+            rpc_client,
+            config,
+            last_general_fee_update: Mutex::new(
+                std::time::Instant::now() - Duration::from_secs(3600), // 1 hour ago
+            ),
+            cached_general_fee: Mutex::new(None),
+        }
+    }
+
+    /// Get fee estimate for claiming transactions
+    /// This estimates the cost of sending a claim transaction
+    pub async fn estimate_claim_fee(&self, execution_account: &Pubkey) -> Result<FeeEstimate> {
+        // For claiming, we need to check fees for the execution account
+        self.get_prioritization_fees_for_accounts(&[*execution_account])
+            .await
+    }
+
+    /// Get fee estimate for proving transactions
+    /// This estimates the cost of sending a proof submission transaction
+    pub async fn estimate_proving_fee(&self, accounts: &[Pubkey]) -> Result<FeeEstimate> {
+        // For proving, we need to check fees for all accounts involved in the transaction
+        self.get_prioritization_fees_for_accounts(accounts).await
+    }
+
+    /// Get general fee estimate when no specific accounts are known
+    pub async fn estimate_general_fee(&self) -> Result<FeeEstimate> {
+        {
+            let last_update = self.last_general_fee_update.lock().unwrap();
+            if last_update.elapsed().as_secs() < self.config.cache_duration_secs {
+                if let Some(cached_fee) = self.cached_general_fee.lock().unwrap().as_ref() {
+                    return Ok(cached_fee.clone());
+                }
+            }
+        }
+
+        let fee_estimate = self.get_recent_prioritization_fees().await?;
+
+        {
+            let mut last_update = self.last_general_fee_update.lock().unwrap();
+            let mut cached_fee = self.cached_general_fee.lock().unwrap();
+            *last_update = std::time::Instant::now();
+            *cached_fee = Some(fee_estimate.clone());
+        }
+
+        Ok(fee_estimate)
+    }
+
+    pub fn calculate_transaction_cost(
+        &self,
+        compute_units: u64,
+        fee_estimate: &FeeEstimate,
+    ) -> u64 {
+        // Convert micro-lamports to lamports (1 lamport = 1_000_000 micro-lamports)
+        (fee_estimate.micro_lamports_per_cu * compute_units) / 1_000_000
+    }
+
+    /// Check if a transaction is profitable given costs and tip
+    pub fn is_profitable(&self, tip_lamports: u64, claim_cost: u64, proving_cost: u64) -> bool {
+        let total_cost = claim_cost + proving_cost;
+        tip_lamports > total_cost
+    }
+
+    /// Get prioritization fees for specific accounts
+    async fn get_prioritization_fees_for_accounts(
+        &self,
+        accounts: &[Pubkey],
+    ) -> Result<FeeEstimate> {
+        match self
+            .rpc_client
+            .get_recent_prioritization_fees(accounts)
+            .await
+        {
+            Ok(fees) => {
+                if fees.is_empty() {
+                    warn!("No prioritization fees returned for accounts, using default");
+                    return Ok(FeeEstimate {
+                        micro_lamports_per_cu: self.config.default_micro_lamports_per_cu,
+                    });
+                }
+
+                // Calculate configured percentile from the recent fees
+                let mut fee_values: Vec<u64> = fees.iter().map(|f| f.prioritization_fee).collect();
+                fee_values.sort_unstable();
+
+                let len = fee_values.len();
+                let percentile_fee = if len > 0 {
+                    let percentile_index = (len * self.config.percentile as usize) / 100;
+                    // Ensure index is within bounds
+                    let index = std::cmp::min(percentile_index, len - 1);
+                    fee_values[index]
+                } else {
+                    self.config.default_micro_lamports_per_cu
+                };
+
+                Ok(FeeEstimate {
+                    micro_lamports_per_cu: percentile_fee,
+                })
+            }
+            Err(e) => {
+                error!("Failed to get prioritization fees for accounts: {:?}", e);
+                // Return fallback fee estimate
+                Ok(FeeEstimate {
+                    micro_lamports_per_cu: self.config.fallback_micro_lamports_per_cu,
+                })
+            }
+        }
+    }
+
+    /// Get recent prioritization fees (general)
+    async fn get_recent_prioritization_fees(&self) -> Result<FeeEstimate> {
+        match self.rpc_client.get_recent_prioritization_fees(&[]).await {
+            Ok(fees) => {
+                if fees.is_empty() {
+                    warn!("No recent prioritization fees available, using default");
+                    return Ok(FeeEstimate {
+                        micro_lamports_per_cu: self.config.default_micro_lamports_per_cu,
+                    });
+                }
+
+                // Calculate configured percentile from the recent fees
+                let mut fee_values: Vec<u64> = fees.iter().map(|f| f.prioritization_fee).collect();
+                fee_values.sort_unstable();
+
+                let len = fee_values.len();
+                let percentile_fee = if len > 0 {
+                    let percentile_index = (len * self.config.percentile as usize) / 100;
+                    // Ensure index is within bounds
+                    let index = std::cmp::min(percentile_index, len - 1);
+                    fee_values[index]
+                } else {
+                    self.config.default_micro_lamports_per_cu
+                };
+
+                info!(
+                    "Updated general fee estimate: {} micro-lamports per CU ({}th percentile)",
+                    percentile_fee, self.config.percentile
+                );
+
+                Ok(FeeEstimate {
+                    micro_lamports_per_cu: percentile_fee,
+                })
+            }
+            Err(e) => {
+                error!("Failed to get recent prioritization fees: {:?}", e);
+                // Return fallback fee estimate
+                Ok(FeeEstimate {
+                    micro_lamports_per_cu: self.config.fallback_micro_lamports_per_cu,
+                })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_transaction_cost() {
+        let fee_service = FeeService::new(
+            Arc::new(RpcClient::new("http://localhost:8899".to_string())),
+            FeeServiceConfig::default(),
+        );
+
+        let fee_estimate = FeeEstimate {
+            micro_lamports_per_cu: 1_500, // example fee
+        };
+
+        // Test with 200,000 compute units (typical transaction)
+        let cost = fee_service.calculate_transaction_cost(200_000, &fee_estimate);
+        // Should be (1_500 * 200_000) / 1_000_000 = 300 lamports
+        assert_eq!(cost, 300);
+    }
+
+    #[test]
+    fn test_is_profitable() {
+        let fee_service = FeeService::new(
+            Arc::new(RpcClient::new("http://localhost:8899".to_string())),
+            FeeServiceConfig::default(),
+        );
+
+        // Case where it's profitable
+        assert!(fee_service.is_profitable(1000, 300, 200)); // tip=1000, costs=500 total
+
+        // Case where it's not profitable
+        assert!(!fee_service.is_profitable(400, 300, 200)); // tip=400, costs=500 total
+
+        // Edge case where costs equal tip
+        assert!(!fee_service.is_profitable(500, 300, 200)); // tip=500, costs=500 total
+    }
+
+    #[tokio::test]
+    async fn test_fee_service_with_mock_data() {
+        let fee_service = FeeService::new(
+            Arc::new(RpcClient::new("http://localhost:8899".to_string())),
+            FeeServiceConfig::default(),
+        );
+
+        // Test fallback behavior when RPC calls fail
+        let fake_account = Pubkey::new_unique();
+        let result = fee_service.estimate_claim_fee(&fake_account).await;
+
+        // Should fallback to default configuration
+        assert!(result.is_ok());
+        let fee_estimate = result.unwrap();
+        assert_eq!(fee_estimate.micro_lamports_per_cu, 5_000); // fallback value
+    }
+
+    #[test]
+    fn test_percentile_calculation() {
+        // Test helper function to simulate percentile calculation
+        fn calculate_percentile(values: &[u64], percentile: u8) -> u64 {
+            let mut sorted_values = values.to_vec();
+            sorted_values.sort_unstable();
+
+            let len = sorted_values.len();
+            if len > 0 {
+                let percentile_index = (len * percentile as usize) / 100;
+                let index = std::cmp::min(percentile_index, len - 1);
+                sorted_values[index]
+            } else {
+                0
+            }
+        }
+
+        // Test case 1: Even distribution
+        let fees = vec![100, 200, 300, 400, 500, 600, 700, 800, 900, 1000];
+
+        assert_eq!(calculate_percentile(&fees, 50), 500); // 50th percentile (median)
+        assert_eq!(calculate_percentile(&fees, 75), 700); // 75th percentile
+        assert_eq!(calculate_percentile(&fees, 90), 900); // 90th percentile
+        assert_eq!(calculate_percentile(&fees, 95), 900); // 95th percentile (same as 90th for 10 values)
+
+        // Test case 2: Single value
+        let single_fee = vec![1000];
+        assert_eq!(calculate_percentile(&single_fee, 75), 1000);
+
+        // Test case 3: Two values
+        let two_fees = vec![100, 200];
+        assert_eq!(calculate_percentile(&two_fees, 75), 100); // 75% of 2 = 1.5 -> index 1 (min with len-1)
+
+        // Test case 4: Empty array
+        let empty_fees: Vec<u64> = vec![];
+        assert_eq!(calculate_percentile(&empty_fees, 75), 0);
+    }
+
+    #[test]
+    fn test_fee_service_config_default() {
+        let config = FeeServiceConfig::default();
+
+        assert_eq!(config.cache_duration_secs, 5);
+        assert_eq!(config.default_micro_lamports_per_cu, 1_000);
+        assert_eq!(config.fallback_micro_lamports_per_cu, 5_000);
+        assert_eq!(config.percentile, 75); // Verify default is 75th percentile
+    }
+
+    #[test]
+    fn test_fee_service_config_custom_percentile() {
+        let config = FeeServiceConfig {
+            cache_duration_secs: 10,
+            default_micro_lamports_per_cu: 2_000,
+            fallback_micro_lamports_per_cu: 10_000,
+            percentile: 90, // Custom 90th percentile
+        };
+
+        let fee_service = FeeService::new(
+            Arc::new(RpcClient::new("http://localhost:8899".to_string())),
+            config.clone(),
+        );
+
+        // Verify the config is stored correctly
+        assert_eq!(fee_service.config.percentile, 90);
+        assert_eq!(fee_service.config.cache_duration_secs, 10);
+        assert_eq!(fee_service.config.default_micro_lamports_per_cu, 2_000);
+        assert_eq!(fee_service.config.fallback_micro_lamports_per_cu, 10_000);
+    }
+
+    #[test]
+    fn test_edge_cases_percentile_bounds() {
+        // Test edge cases for percentile calculation
+        let config_0 = FeeServiceConfig {
+            percentile: 0,
+            ..Default::default()
+        };
+
+        let config_100 = FeeServiceConfig {
+            percentile: 100,
+            ..Default::default()
+        };
+
+        let fee_service_0 = FeeService::new(
+            Arc::new(RpcClient::new("http://localhost:8899".to_string())),
+            config_0,
+        );
+
+        let fee_service_100 = FeeService::new(
+            Arc::new(RpcClient::new("http://localhost:8899".to_string())),
+            config_100,
+        );
+
+        // These should not panic and should create valid fee services
+        assert_eq!(fee_service_0.config.percentile, 0);
+        assert_eq!(fee_service_100.config.percentile, 100);
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,6 +1,7 @@
 pub mod types;
 #[macro_use]
 pub mod observe;
+mod fee_service;
 mod ingest;
 
 pub mod config;

--- a/node/src/observe/mod.rs
+++ b/node/src/observe/mod.rs
@@ -29,6 +29,11 @@ pub enum MetricEvents {
     IncompatibleProverVersion,
     ProofSubmissionError,
     TransactionExpired,
+    UnprofitableExecution,
+    ExecutionAddedToRetryQueue,
+    ExecutionRetried,
+    ExecutionRemovedFromRetryQueue,
+    ExecutionRetryExpired,
 }
 
 macro_rules! emit_event {

--- a/node/src/risc0_runner/mod.rs
+++ b/node/src/risc0_runner/mod.rs
@@ -11,6 +11,7 @@ use {
 use {
     crate::{
         config::ProverNodeConfig,
+        fee_service::FeeService,
         observe::*,
         risc0_runner::utils::async_to_json,
         transaction_sender::{RpcTransactionSender, TransactionSender},
@@ -118,6 +119,7 @@ pub struct Risc0Runner {
     self_identity: Arc<Pubkey>,
     inflight_proofs: InflightProofs,
     input_resolver: Arc<dyn InputResolver + 'static>,
+    fee_service: Arc<FeeService>,
 }
 
 impl Risc0Runner {
@@ -148,6 +150,11 @@ impl Risc0Runner {
             }
         }
 
+        let fee_service = Arc::new(FeeService::new(
+            txn_sender.rpc_client.clone(),
+            config.fee_service_config.clone(),
+        ));
+
         Ok(Risc0Runner {
             config: Arc::new(config),
             loaded_images: Arc::new(loaded_images),
@@ -158,6 +165,7 @@ impl Risc0Runner {
             self_identity: Arc::new(self_identity),
             inflight_proofs: Arc::new(DashMap::new()),
             input_resolver,
+            fee_service,
         })
     }
 
@@ -242,6 +250,7 @@ impl Risc0Runner {
         let inflight_proofs = self.inflight_proofs.clone();
         let txn_sender = self.txn_sender.clone();
         let input_resolver = self.input_resolver.clone();
+        let fee_service = self.fee_service.clone();
         self.worker_handle = Some(tokio::spawn(async move {
             while let Some(bix) = rx.recv().await {
                 let txn_sender = txn_sender.clone();
@@ -252,6 +261,7 @@ impl Risc0Runner {
                 let self_id = self_id.clone();
                 let input_staging_area = input_staging_area.clone();
                 let inflight_proofs = inflight_proofs.clone();
+                let fee_service = fee_service.clone();
                 tokio::spawn(async move {
                     let bonsol_ix_type =
                         parse_ix_data(&bix.data).map_err(|_| Risc0RunnerError::InvalidData)?;
@@ -302,6 +312,7 @@ impl Risc0Runner {
                                 bix.last_known_block,
                                 payload,
                                 &bix.accounts,
+                                fee_service.clone(),
                             )
                             .await
                         }
@@ -486,6 +497,7 @@ async fn handle_execution_request<'a>(
     _execution_block: u64,
     exec: ExecutionRequestV1<'a>,
     accounts: &[Pubkey],
+    fee_service: Arc<FeeService>,
 ) -> Result<()> {
     if !can_execute(exec) {
         warn!(
@@ -553,6 +565,83 @@ async fn handle_execution_request<'a>(
         let computable_by = expiry / 2;
 
         if computable_by < expiry {
+            // Check profitability before claiming using the fee service
+            let tip_lamports = exec.tip();
+            let execution_account = accounts[2];
+
+            // Estimate claiming fee
+            let claim_fee_estimate = match fee_service.estimate_claim_fee(&execution_account).await
+            {
+                Ok(estimate) => estimate,
+                Err(e) => {
+                    warn!("Failed to estimate claim fee: {:?}, using general fee", e);
+                    fee_service
+                        .estimate_general_fee()
+                        .await
+                        .unwrap_or_else(|_| {
+                            warn!("Failed to get general fee estimate, using default");
+                            crate::fee_service::FeeEstimate {
+                                micro_lamports_per_cu: 1_000,
+                            }
+                        })
+                }
+            };
+
+            // Estimate proving fee (using callback accounts if available)
+            let proving_accounts: Vec<Pubkey> =
+                if let Some(callback_accounts) = exec.callback_extra_accounts() {
+                    callback_accounts
+                        .iter()
+                        .map(|a| {
+                            let pkbytes: [u8; 32] = a.pubkey().into();
+                            Pubkey::try_from(pkbytes).unwrap_or_default()
+                        })
+                        .collect()
+                } else {
+                    vec![execution_account]
+                };
+
+            let proving_fee_estimate =
+                match fee_service.estimate_proving_fee(&proving_accounts).await {
+                    Ok(estimate) => estimate,
+                    Err(e) => {
+                        warn!("Failed to estimate proving fee: {:?}, using general fee", e);
+                        fee_service
+                            .estimate_general_fee()
+                            .await
+                            .unwrap_or_else(|_| {
+                                warn!("Failed to get general fee estimate, using default");
+                                crate::fee_service::FeeEstimate {
+                                    micro_lamports_per_cu: 1_000,
+                                }
+                            })
+                    }
+                };
+
+            // Calculate transaction costs (assuming ~200k CU for claiming, ~400k CU for proving)
+            let claim_cost = fee_service.calculate_transaction_cost(200_000, &claim_fee_estimate);
+            let proving_cost =
+                fee_service.calculate_transaction_cost(400_000, &proving_fee_estimate);
+
+            // Check if this execution is profitable
+            if !fee_service.is_profitable(tip_lamports, claim_cost, proving_cost) {
+                info!(
+                    "Execution {} not profitable: tip={}, claim_cost={}, proving_cost={}, total_cost={}",
+                    eid, tip_lamports, claim_cost, proving_cost, claim_cost + proving_cost
+                );
+                emit_event!(MetricEvents::UnprofitableExecution, execution_id => eid);
+                return Ok(());
+            }
+
+            info!(
+                "Execution {} is profitable: tip={}, claim_cost={}, proving_cost={}, profit={}",
+                eid,
+                tip_lamports,
+                claim_cost,
+                proving_cost,
+                tip_lamports - (claim_cost + proving_cost)
+            );
+
             //the way this is done can cause race conditions where so many request come in a short time that we accept
             // them before we change the value of g so we optimistically change to inflight and we will decrement if we dont win the claim
             let inputs = exec.input().ok_or(Risc0RunnerError::InvalidData)?;
@@ -648,14 +737,14 @@ async fn handle_image_deployment<'a>(
     loaded_images: LoadedImageMapRef<'a>,
 ) -> Result<()> {
     let url = deploy.url().ok_or(Risc0RunnerError::InvalidData)?;
-    let size = deploy.size_();
+    let size = deploy.size();
     let image_id = deploy.image_id().unwrap_or_default();
     let program_name = deploy.program_name().unwrap_or_default();
-    
+
     info!("Attempting to download image from URL: {}", url);
     info!("Image ID: {}, Size: {}", image_id, size);
     info!("Program name: {}", program_name);
-    
+
     emit_histogram!(MetricEvents::ImageDownload, size as f64, url => url.to_string());
     emit_event_with_duration!(MetricEvents::ImageDownload, {
         // The URL from deployment data already includes the full path


### PR DESCRIPTION
# Fee Service 

## Overview
This PR implements a fee service system for the Bonsol prover node to enable fee estimation for execution requests. The implementation adds configurable percentile-based fee estimation with caching, integration with Solana RPC prioritization fees, and profitability checks before claiming execution requests.

##  Features

### 1. **Configurable Fee Service**
- **Percentile-based fee estimation**: Uses configurable percentiles (default 75th) for competitive fee calculation
- **Caching**: 5-second cache duration to reduce RPC calls
- **Multiple fee estimation methods**: General fees, account-specific fees, and claim/proving fees

### 2. **Profitability Analysis**
- **Cost calculation**: Estimates transaction costs based on compute units and current network fees
- **Profit optimization**: Only processes profitable execution requests
- **Dynamic fee adjustment**: Adapts to network congestion automatically

### 3. **Integration with Risc0Runner**
- **profitability checks**: Executions are evaluated for profitability before claiming
- **Fee-aware execution**: Uses fee data for execution decisions

### Testing 

The fee service has unit tests in `node/src/fee_service.rs` covering core functionality:

- Transaction cost calculation (converting micro-lamports to lamports) 
- Profitability analysis (comparing tips vs costs)
- Fallback behaviour when RPC calls fail and proper bounds checking for percentile calculations